### PR TITLE
[Fix] #20 github.sha 7자리로 IMAGE_TAG 통일

### DIFF
--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -37,6 +37,6 @@ jobs:
           key: ${{ secrets.EC2_KEY }}
           script: |
             cd ~/app/deployment
-            export IMAGE_TAG=${GITHUB_SHA:0:7}
+            export IMAGE_TAG=${{ github.sha }}
             chmod +x deploy.sh
             ./deploy.sh

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ jib {
         image = "${System.getenv('ECR_REGISTRY')}/${System.getenv('ECR_REPOSITORY')}"
 
         tags = [
-                System.getenv('GITHUB_SHA')?.take(7)
+                System.getenv('GITHUB_SHA')
         ]
     }
 


### PR DESCRIPTION
## Related issue 🛠
- closed #이슈넘버

## Work Description 📝
- 작업 내용

## ScreenShots 📷

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **관리 업무**
  * 배포 파이프라인과 빌드 구성에서 이미지 태그 생성 방식을 단일화하여 전체 커밋 SHA를 사용하도록 변경했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->