### PR TITLE
[Chore] #20 CD 테스트 종료에 따른 타겟 브랜치 원래대로 복구

### DIFF
--- a/.github/workflows/cd-main.yml
+++ b/.github/workflows/cd-main.yml
@@ -2,7 +2,7 @@ name: cd-main
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
     paths:
       - 'src/**'
       - 'build.gradle'

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,7 +1,7 @@
 name: ci-main
 on:
   pull_request:
-    branches: [main, develop]
+    branches: [main]
     types: [opened, synchronize, reopened]
     paths-ignore:
       - '**/*.md'


### PR DESCRIPTION
## Related issue 🛠
- closed #20

## Work Description 📝
- CD 테스트가 종료됨에 따라 main-ci와 cd를 main 브랜치에 대해 트리거되도록 변경했습니다.
### 1. cd-main.yml

### (1) 배포 파일 전송
- deployment/* 디렉토리를 EC2의 /home/ubuntu/app으로 복사합니다.

### (2) EC2에서 deploy.sh 실행하여 블루그린 배포 실행
- docker-compose.yml 기준으로 Blue/Green 두 컨테이너를 동시에 운영하기 용이하게 구성했습니다.
- 컨테이너 내부 앱 포트: 8082(prod 환경)
- 호스트 포트 매핑: blue - 8080, green - 8082
- 현재 실행중인 컨테이너를 확인하고, 다른 컨테이너를 새 이미지로 기동합니다. http://127.0.0.1:$TARGET_PORT/actuator/health로 헬스 체크 후 성공하면 service-url.inc 갱신을 통해 트래픽을 전환하고, nginx를 reload합니다. 그 후 기존 컨테이너를 종료하고 불필요한 이미지를 정리합니다.
- 이미지의 경우 AWS에서 한 번에 관리하는게 유용할 것 같아 ECR을 사용했습니다.

### 2. HTTPS 처리
- ALB와 ACM 인증서를 이용하여 HTTPS 인증서 처리를 해주었습니다. (AWS에서 인증을 관리해주니 편리)

## ScreenShots 📷

## To Reviewers 📢
