### PR TITLE
[Chore] 스웨거 보안 설정

### DIFF
--- a/src/main/java/org/sopt/kareer/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/kareer/global/config/security/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.sopt.kareer.global.oauth.handler.OAuth2AuthenticationSuccessHandler;
 import org.sopt.kareer.global.oauth.service.CustomOidcOAuth2UserService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -31,9 +32,6 @@ public class SecurityConfig {
             "/",
             "/api/v1/auth/**",
             "/api/v1/rag/**",
-            "/swagger-ui/**",
-            "/swagger-resources/**",
-            "/v3/api-docs/**",
             "/actuator/health",
             "/h2-console/**",
             "/error",
@@ -57,7 +55,7 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .cors(cors -> cors.configurationSource(corsConfigurationSource))
                 .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
+                .httpBasic(Customizer.withDefaults())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers(headers -> headers.frameOptions(FrameOptionsConfig::sameOrigin))
                 .exceptionHandling(exception -> exception
@@ -70,6 +68,8 @@ public class SecurityConfig {
                         .failureHandler(failureHandler)
                 )
                 .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/swagger-ui/**", "/swagger-resources/**", "/v3/api-docs/**")
+                            .hasRole("SWAGGER")
                         .requestMatchers(PERMIT_ALL_PATTERNS).permitAll()
                         .anyRequest().authenticated()
                 )

--- a/src/main/java/org/sopt/kareer/global/config/security/SwaggerSecurityConfig.java
+++ b/src/main/java/org/sopt/kareer/global/config/security/SwaggerSecurityConfig.java
@@ -1,0 +1,35 @@
+package org.sopt.kareer.global.config.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.factory.PasswordEncoderFactories;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+@Configuration
+public class SwaggerSecurityConfig {
+
+    @Value("${swagger.auth.username:swagger}")
+    private String swaggerUsername;
+
+    @Value("${swagger.auth.password}")
+    private String swaggerPassword;
+
+    @Bean
+    public UserDetailsService swaggerUserDetailsService(PasswordEncoder passwordEncoder) {
+        return new InMemoryUserDetailsManager(
+                User.withUsername(swaggerUsername)
+                        .password(passwordEncoder.encode(swaggerPassword))
+                        .roles("SWAGGER")
+                        .build()
+        );
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return PasswordEncoderFactories.createDelegatingPasswordEncoder();
+    }
+}

--- a/src/main/java/org/sopt/kareer/global/jwt/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/org/sopt/kareer/global/jwt/handler/CustomAuthenticationEntryPoint.java
@@ -28,6 +28,14 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
         log.debug("Unauthorized access blocked. path={}, message={}", request.getRequestURI(), authException.getMessage());
+
+        String path = request.getRequestURI();
+        if (path.startsWith("/swagger-ui") || path.startsWith("/swagger-resources") || path.startsWith("/v3/api-docs")) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.setHeader("WWW-Authenticate", "Basic realm=\"Swagger UI\"");
+            return;
+        }
+
         BaseErrorResponse errorResponse = BaseErrorResponse.of(UNAUTHORIZED);
         response.setStatus(errorResponse.getCode());
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,11 @@ spring:
       prod: prod-db, prod-port, prod-cors, common
     active: ${SPRING_ACTIVE_PROFILE}
 
+swagger:
+  auth:
+    username: ${SWAGGER_USERNAME}
+    password: ${SWAGGER_PASSWORD}
+
 ---
 spring:
   config:


### PR DESCRIPTION
## Related issue 🛠
- closed #120 



## Work Description 📝
- SecurityConfig에서 Swagger 경로를 ROLE_SWAGGER로 제한하고 Basic Auth를 활성화했어요.
- Swagger 전용 사용자 정보를 주입하는 SwaggerSecurityConfig를 추가하고, application.yml에 계정 설정을 추가했어요.
- CustomAuthenticationEntryPoint는 Swagger 경로에 한해 WWW-Authenticate 헤더를 보내 기본 인증 챌린지를 띄우도록 수정했어요.

## ScreenShots 📷

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **보안**
  * Swagger UI에 접근하려면 이제 인증이 필요합니다.
  * 환경 변수를 통해 Swagger 사용자 자격증명을 설정할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->