### PR TITLE
[Deploy] Tesseract 네이티브 크래시 방지를 위한 Java 21 베이스 이미지 고정

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,14 @@
-FROM gradle:8.7-jdk21 AS builder
+FROM eclipse-temurin:21-jre-jammy AS artifacts
 WORKDIR /workspace
-COPY . .
-RUN chmod +x gradlew \
- && ./gradlew --no-daemon clean bootJar \
- && cp "$(find build/libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' -print -quit)" app.jar
+COPY build/libs ./libs
+RUN cp "$(find libs -maxdepth 1 -type f -name '*.jar' ! -name '*-plain.jar' -print -quit)" app.jar
 
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:21-jre-jammy
 RUN apt-get update \
  && apt-get install -y \
     tesseract-ocr \
     tesseract-ocr-kor \
     tesseract-ocr-eng \
  && rm -rf /var/lib/apt/lists/*
-COPY --from=builder /workspace/app.jar /app.jar
+COPY --from=artifacts /workspace/app.jar /app.jar
 ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/Dockerfile.tesseract-base
+++ b/Dockerfile.tesseract-base
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:21-jre
+FROM eclipse-temurin:21-jre-jammy
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/build.gradle
+++ b/build.gradle
@@ -103,7 +103,7 @@ clean {
 }
 
 jib {
-    def tessBaseImage = System.getenv('JIB_TESSERACT_BASE_IMAGE') ?: 'eclipse-temurin:21-jre'
+    def tessBaseImage = System.getenv('JIB_TESSERACT_BASE_IMAGE') ?: 'eclipse-temurin:21-jre-jammy'
 
     from {
         image = tessBaseImage


### PR DESCRIPTION
## Related issue 🛠
- closed #124 



## Work Description 📝
- 런타임/베이스 이미지를 eclipse-temurin:21-jre-jammy로 고정했어요. 
- Temurin 21의 기본 태그는 Ubuntu 24.04(noble) 기반이라, apt로 설치한 libtesseract 5.0.3과 glibc 조합에서 SIGSEGV가 반복됐어요.
- Jammy(22.04) 태그는 기존 JDK17 때 사용하던 OS 스택과 동일하므로, Tess4J 네이티브 라이브러리가 안정적으로 동작한다고 해요.

## ScreenShots 📷

## To Reviewers 📢


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * 빌드 프로세스 최적화를 위한 컨테이너 구성 업데이트
  * 기본 런타임 환경 이미지 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->