### PR TITLE
[Refactor] 온보딩 OCR에서 국가 반환 형태 LocalizedItemResponse로 수정

### DIFF
--- a/src/main/java/org/sopt/kareer/domain/member/dto/response/OcrPassportResponse.java
+++ b/src/main/java/org/sopt/kareer/domain/member/dto/response/OcrPassportResponse.java
@@ -12,16 +12,17 @@ public record OcrPassportResponse(
         @Schema(description = "Full Name", example = "Hong Seungwon")
         String fullName,
 
-        @Schema(description = "국가", example = "AFGHANISTAN")
-        Country country,
+        @Schema(description = "국가 코드 및 라벨", example = "{\"code\": \"south-korea\", \"label\": \"South Korea\"}")
+        LocalizedItemResponse country,
 
         @Schema(description = "생년월일")
         LocalDate birthDate
 ) {
    public static OcrPassportResponse from(PassportOcrParser.PassportInfo passportInfo) {
+           Country country = passportInfo.country();
            return OcrPassportResponse.builder()
                    .fullName(passportInfo.fullName())
-                   .country(passportInfo.country())
+                   .country(country != null ? new LocalizedItemResponse(country.getCode(), country.getCountryName()) : null)
                    .birthDate(passportInfo.birthDate())
                    .build();
    }

--- a/src/main/java/org/sopt/kareer/domain/member/entity/enums/Country.java
+++ b/src/main/java/org/sopt/kareer/domain/member/entity/enums/Country.java
@@ -217,6 +217,10 @@ public enum Country {
                     country -> country.countryName.toLowerCase(),
                     Function.identity()));
 
+    public String getCode() {
+        return name().toLowerCase().replace("_", "-");
+    }
+
     public static List<String> getCountries() {
         return Arrays.stream(Country.values())
                 .map(Country::getCountryName)

--- a/src/main/java/org/sopt/kareer/domain/member/service/MemberService.java
+++ b/src/main/java/org/sopt/kareer/domain/member/service/MemberService.java
@@ -310,9 +310,6 @@ public class MemberService {
     public MemberCompletionResponse getCompletion(Long memberId){
         Member member = getById(memberId);
 
-        MemberVisa memberVisa = memberVisaRepository.findActiveByMemberId(memberId)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.VISA_NOT_FOUND));
-
         boolean onboardingRequired = member.getStatus().equals(MemberStatus.PENDING);
         boolean agreedTerm = memberTermRepository.existsByMemberIdAndAgreedTrue(memberId);
 


### PR DESCRIPTION
## Related issue 🛠
- closed #235





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 여권 OCR 인식 결과에서 국가 정보가 국가 코드와 국가명을 함께 제공하도록 개선되었습니다.
  * 멤버 완성도 조회 시 비자 관련 불필요한 검증 로직이 제거되어 시스템 안정성이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->