### PR TITLE
[Feat] SSE 기반 로드맵 생성 단계별 진행 상태 전달

### DIFF
--- a/src/main/java/org/sopt/kareer/domain/jobposting/repository/JobPostingBookmarkRepository.java
+++ b/src/main/java/org/sopt/kareer/domain/jobposting/repository/JobPostingBookmarkRepository.java
@@ -16,7 +16,7 @@ public interface JobPostingBookmarkRepository extends JpaRepository<JobPostingBo
     @Query("""
     SELECT jp
     FROM JobPostingBookmark jpb
-    JOIN FETCH jpb.jobPosting jp
+    JOIN jpb.jobPosting jp
     WHERE jpb.member.id = :memberId
     ORDER BY jp.deadline asc
 """)

--- a/src/main/java/org/sopt/kareer/domain/roadmap/controller/RoadmapApi.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/controller/RoadmapApi.java
@@ -2,12 +2,15 @@ package org.sopt.kareer.domain.roadmap.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletResponse;
 import org.sopt.kareer.domain.roadmap.dto.response.RoadmapTestResponse;
 import org.sopt.kareer.global.annotation.CustomExceptionDescription;
 import org.sopt.kareer.global.response.BaseResponse;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import static org.sopt.kareer.global.config.swagger.SwaggerResponseDescription.CREATE_ROADMAP;
 
@@ -18,6 +21,14 @@ public interface RoadmapApi {
     @CustomExceptionDescription(CREATE_ROADMAP)
     @PostMapping
     ResponseEntity<BaseResponse<Void>> generateRoadmap(@AuthenticationPrincipal Long memberId);
+
+    @Operation(summary = "AI 로드맵 생성 진행 상태 스트림", description = "로드맵을 생성하면서 단계별 진행 상태를 SSE로 전달합니다.")
+    @CustomExceptionDescription(CREATE_ROADMAP)
+    @PostMapping(value = "/generations/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    SseEmitter generateRoadmapStream(
+            @AuthenticationPrincipal Long memberId,
+            HttpServletResponse response
+    );
 
     @Operation(summary = "AI 로드맵 생성 테스트용 (Server Only)", description = "사용자가 온보딩에 입력한 정보를 통해 로드맵을 생성합니다.")
     @CustomExceptionDescription(CREATE_ROADMAP)

--- a/src/main/java/org/sopt/kareer/domain/roadmap/controller/RoadmapController.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/controller/RoadmapController.java
@@ -1,14 +1,17 @@
 package org.sopt.kareer.domain.roadmap.controller;
 
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.sopt.kareer.domain.roadmap.dto.response.RoadmapTestResponse;
 import org.sopt.kareer.domain.roadmap.facade.RoadmapGenerateFacade;
+import org.sopt.kareer.domain.roadmap.service.RoadmapGenerationSseService;
 import org.sopt.kareer.global.response.BaseResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RestController
 @RequiredArgsConstructor
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class RoadmapController implements RoadmapApi {
 
     private final RoadmapGenerateFacade roadmapGenerateFacade;
+    private final RoadmapGenerationSseService roadmapGenerationSseService;
 
     @Override
     public ResponseEntity<BaseResponse<Void>> generateRoadmap(
@@ -25,6 +29,16 @@ public class RoadmapController implements RoadmapApi {
 
         return ResponseEntity.status(HttpStatus.OK)
                 .body(BaseResponse.ok("AI 로드맵 생성에 성공하였습니다."));
+    }
+
+    @Override
+    public SseEmitter generateRoadmapStream(
+            @AuthenticationPrincipal Long memberId,
+            HttpServletResponse response
+    ) {
+        response.setHeader("Cache-Control", "no-cache");
+        response.setHeader("X-Accel-Buffering", "no");
+        return roadmapGenerationSseService.generate(memberId);
     }
 
     @Override

--- a/src/main/java/org/sopt/kareer/domain/roadmap/dto/response/RoadmapGenerationCompletedEvent.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/dto/response/RoadmapGenerationCompletedEvent.java
@@ -1,0 +1,8 @@
+package org.sopt.kareer.domain.roadmap.dto.response;
+
+public record RoadmapGenerationCompletedEvent(String status) {
+
+    public static RoadmapGenerationCompletedEvent completed() {
+        return new RoadmapGenerationCompletedEvent("COMPLETED");
+    }
+}

--- a/src/main/java/org/sopt/kareer/domain/roadmap/dto/response/RoadmapGenerationFailedEvent.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/dto/response/RoadmapGenerationFailedEvent.java
@@ -1,0 +1,20 @@
+package org.sopt.kareer.domain.roadmap.dto.response;
+
+import org.sopt.kareer.domain.roadmap.progress.RoadmapGenerationStep;
+
+public record RoadmapGenerationFailedEvent(
+        RoadmapGenerationStep step,
+        String status,
+        String code,
+        String message
+) {
+
+    public static RoadmapGenerationFailedEvent of(RoadmapGenerationStep step) {
+        return new RoadmapGenerationFailedEvent(
+                step,
+                "FAILED",
+                "ROADMAP_GENERATION_FAILED",
+                "로드맵 생성에 실패했습니다."
+        );
+    }
+}

--- a/src/main/java/org/sopt/kareer/domain/roadmap/dto/response/RoadmapProgressEvent.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/dto/response/RoadmapProgressEvent.java
@@ -1,0 +1,35 @@
+package org.sopt.kareer.domain.roadmap.dto.response;
+
+import org.sopt.kareer.domain.roadmap.progress.RoadmapGenerationStep;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapProgressStatus;
+
+public record RoadmapProgressEvent(
+        int sequence,
+        RoadmapGenerationStep step,
+        RoadmapProgressStatus status
+) {
+
+    public static RoadmapProgressEvent started(RoadmapGenerationStep step) {
+        return new RoadmapProgressEvent(
+                step.getSequence(),
+                step,
+                RoadmapProgressStatus.STARTED
+        );
+    }
+
+    public static RoadmapProgressEvent completed(RoadmapGenerationStep step) {
+        return new RoadmapProgressEvent(
+                step.getSequence(),
+                step,
+                RoadmapProgressStatus.COMPLETED
+        );
+    }
+
+    public static RoadmapProgressEvent failed(RoadmapGenerationStep step) {
+        return new RoadmapProgressEvent(
+                step.getSequence(),
+                step,
+                RoadmapProgressStatus.FAILED
+        );
+    }
+}

--- a/src/main/java/org/sopt/kareer/domain/roadmap/facade/RoadmapGenerateFacade.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/facade/RoadmapGenerateFacade.java
@@ -8,6 +8,9 @@ import org.sopt.kareer.domain.member.service.MemberQueryService;
 import org.sopt.kareer.domain.roadmap.dto.response.RoadmapResponse;
 import org.sopt.kareer.domain.roadmap.dto.response.RoadmapTestResponse;
 import org.sopt.kareer.domain.roadmap.dto.translation.RoadmapTranslationTarget;
+import org.sopt.kareer.domain.roadmap.progress.NoOpRoadmapProgressNotifier;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapGenerationStep;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapProgressNotifier;
 import org.sopt.kareer.domain.roadmap.service.RoadMapPersistService;
 import org.sopt.kareer.domain.roadmap.service.RoadmapGenerateService;
 import org.sopt.kareer.domain.roadmap.service.RoadmapTranslationPersistService;
@@ -36,19 +39,42 @@ public class RoadmapGenerateFacade {
     private final ExecutorService executorService;
 
     public void generateRoadmap(Long memberId) {
-        Member member = memberQueryService.getMemberById(memberId);
-        MemberVisa visa = memberQueryService.getVisaByMemberId(memberId);
+        generateRoadmap(memberId, NoOpRoadmapProgressNotifier.INSTANCE);
+    }
 
-        RoadmapGenerationContext context = roadmapGenerateService.prepareGeneration(member, visa);
+    public void generateRoadmap(Long memberId, RoadmapProgressNotifier progressNotifier) {
+        progressNotifier.started(RoadmapGenerationStep.USER_ANALYSIS);
 
-        RoadmapResponse response = openAiService.generateRoadmap(
-                context.memberContextText(),
-                context.visaDocs(),
-                context.careerDocs(),
-                context.policyDocs()
-        );
+        Member member;
+        MemberVisa visa;
+        try {
+            member = memberQueryService.getMemberById(memberId);
+            visa = memberQueryService.getVisaByMemberId(memberId);
+        } catch (RuntimeException exception) {
+            progressNotifier.failed(RoadmapGenerationStep.USER_ANALYSIS);
+            throw exception;
+        }
 
-        RoadmapTranslationTarget target = roadMapPersistService.saveRoadMap(member, response);
+        RoadmapGenerationContext context = roadmapGenerateService.prepareGeneration(member, visa, progressNotifier);
+        progressNotifier.completed(RoadmapGenerationStep.POLICY_SEARCH);
+        progressNotifier.started(RoadmapGenerationStep.ROADMAP_WRITING);
+
+        RoadmapTranslationTarget target;
+        try {
+            RoadmapResponse response = openAiService.generateRoadmap(
+                    context.memberContextText(),
+                    context.visaDocs(),
+                    context.careerDocs(),
+                    context.policyDocs()
+            );
+
+            target = roadMapPersistService.saveRoadMap(member, response);
+            progressNotifier.completed(RoadmapGenerationStep.ROADMAP_WRITING);
+        } catch (RuntimeException exception) {
+            progressNotifier.failed(RoadmapGenerationStep.ROADMAP_WRITING);
+            throw exception;
+        }
+
         translateAllLanguages(target);
     }
 

--- a/src/main/java/org/sopt/kareer/domain/roadmap/progress/NoOpRoadmapProgressNotifier.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/progress/NoOpRoadmapProgressNotifier.java
@@ -1,0 +1,18 @@
+package org.sopt.kareer.domain.roadmap.progress;
+
+public enum NoOpRoadmapProgressNotifier implements RoadmapProgressNotifier {
+
+    INSTANCE;
+
+    @Override
+    public void started(RoadmapGenerationStep step) {
+    }
+
+    @Override
+    public void completed(RoadmapGenerationStep step) {
+    }
+
+    @Override
+    public void failed(RoadmapGenerationStep step) {
+    }
+}

--- a/src/main/java/org/sopt/kareer/domain/roadmap/progress/RoadmapGenerationStep.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/progress/RoadmapGenerationStep.java
@@ -1,0 +1,15 @@
+package org.sopt.kareer.domain.roadmap.progress;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoadmapGenerationStep {
+
+    USER_ANALYSIS(1),
+    POLICY_SEARCH(2),
+    ROADMAP_WRITING(3);
+
+    private final int sequence;
+}

--- a/src/main/java/org/sopt/kareer/domain/roadmap/progress/RoadmapProgressNotifier.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/progress/RoadmapProgressNotifier.java
@@ -1,0 +1,10 @@
+package org.sopt.kareer.domain.roadmap.progress;
+
+public interface RoadmapProgressNotifier {
+
+    void started(RoadmapGenerationStep step);
+
+    void completed(RoadmapGenerationStep step);
+
+    void failed(RoadmapGenerationStep step);
+}

--- a/src/main/java/org/sopt/kareer/domain/roadmap/progress/RoadmapProgressStatus.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/progress/RoadmapProgressStatus.java
@@ -1,0 +1,7 @@
+package org.sopt.kareer.domain.roadmap.progress;
+
+public enum RoadmapProgressStatus {
+    STARTED,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/org/sopt/kareer/domain/roadmap/progress/SseRoadmapProgressNotifier.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/progress/SseRoadmapProgressNotifier.java
@@ -1,0 +1,64 @@
+package org.sopt.kareer.domain.roadmap.progress;
+
+import org.sopt.kareer.domain.roadmap.dto.response.RoadmapProgressEvent;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+public class SseRoadmapProgressNotifier implements RoadmapProgressNotifier {
+
+    private static final String EVENT_NAME = "roadmap-progress";
+
+    private final SseEmitter emitter;
+    private final AtomicBoolean connected = new AtomicBoolean(true);
+    private final AtomicReference<RoadmapGenerationStep> currentStep = new AtomicReference<>();
+
+    public SseRoadmapProgressNotifier(SseEmitter emitter) {
+        this.emitter = emitter;
+    }
+
+    @Override
+    public void started(RoadmapGenerationStep step) {
+        currentStep.set(step);
+        send(RoadmapProgressEvent.started(step));
+    }
+
+    @Override
+    public void completed(RoadmapGenerationStep step) {
+        send(RoadmapProgressEvent.completed(step));
+    }
+
+    @Override
+    public void failed(RoadmapGenerationStep step) {
+        currentStep.set(step);
+        send(RoadmapProgressEvent.failed(step));
+    }
+
+    public RoadmapGenerationStep currentStep() {
+        return currentStep.get();
+    }
+
+    public boolean isConnected() {
+        return connected.get();
+    }
+
+    public void disconnect() {
+        connected.set(false);
+    }
+
+    private void send(RoadmapProgressEvent event) {
+        if (!connected.get()) {
+            return;
+        }
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name(EVENT_NAME)
+                    .data(event));
+        } catch (IOException | IllegalStateException e) {
+            disconnect();
+        }
+    }
+}

--- a/src/main/java/org/sopt/kareer/domain/roadmap/service/RoadmapGenerateService.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/service/RoadmapGenerateService.java
@@ -4,6 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.kareer.domain.member.entity.Member;
 import org.sopt.kareer.domain.member.entity.MemberVisa;
 import org.sopt.kareer.domain.roadmap.entity.enums.RoadmapActiveStatus;
+import org.sopt.kareer.domain.roadmap.progress.NoOpRoadmapProgressNotifier;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapGenerationStep;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapProgressNotifier;
 import org.sopt.kareer.domain.roadmap.repository.ActionItemRepository;
 import org.sopt.kareer.domain.roadmap.repository.RoadmapRepository;
 import org.sopt.kareer.domain.roadmap.service.dto.response.RoadmapGenerationContext;
@@ -29,23 +32,49 @@ public class RoadmapGenerateService {
 
     @Transactional
     public RoadmapGenerationContext prepareGeneration(Member member, MemberVisa visa) {
-        roadmapRepository.findByMember_IdAndStatus(member.getId(), RoadmapActiveStatus.ACTIVE)
-                .ifPresent(existing -> {
-                    actionItemRepository.deactivateAllByRoadmapId(existing.getId());
-                    existing.deactivate();
-                });
+        return prepareGeneration(member, visa, NoOpRoadmapProgressNotifier.INSTANCE);
+    }
 
-        return buildContext(member, visa, false);
+    @Transactional
+    public RoadmapGenerationContext prepareGeneration(
+            Member member,
+            MemberVisa visa,
+            RoadmapProgressNotifier progressNotifier
+    ) {
+        RoadmapGenerationStep currentStep = RoadmapGenerationStep.USER_ANALYSIS;
+
+        try {
+            roadmapRepository.findByMember_IdAndStatus(member.getId(), RoadmapActiveStatus.ACTIVE)
+                    .ifPresent(existing -> {
+                        actionItemRepository.deactivateAllByRoadmapId(existing.getId());
+                        existing.deactivate();
+                    });
+
+            var memberContext = memberContextBuilder.load(member.getId());
+            progressNotifier.completed(RoadmapGenerationStep.USER_ANALYSIS);
+
+            currentStep = RoadmapGenerationStep.POLICY_SEARCH;
+            progressNotifier.started(currentStep);
+
+            return buildContext(member, visa, false, memberContext.contextText());
+        } catch (RuntimeException exception) {
+            progressNotifier.failed(currentStep);
+            throw exception;
+        }
     }
 
     @Transactional(readOnly = true)
     public RoadmapGenerationContext prepareTestGeneration(Member member, MemberVisa visa) {
-        return buildContext(member, visa, true);
+        var memberContext = memberContextBuilder.load(member.getId());
+        return buildContext(member, visa, true, memberContext.contextText());
     }
 
-    private RoadmapGenerationContext buildContext(Member member, MemberVisa visa, boolean requireVisa) {
-        var memberContext = memberContextBuilder.load(member.getId());
-
+    private RoadmapGenerationContext buildContext(
+            Member member,
+            MemberVisa visa,
+            boolean requireVisa,
+            String memberContextText
+    ) {
         List<Document> visaDocs = requireVisa
                 ? requiredRetriever.retrieveVisaAll(visa)
                 : (visa == null ? List.of() : requiredRetriever.retrieveVisaAll(visa));
@@ -58,6 +87,6 @@ public class RoadmapGenerateService {
 
         List<Document> policyDocs = policyDocumentRetriever.retrievePolicy(member, visa);
 
-        return new RoadmapGenerationContext(memberContext.contextText(), visaDocs, careerDocs, policyDocs);
+        return new RoadmapGenerationContext(memberContextText, visaDocs, careerDocs, policyDocs);
     }
 }

--- a/src/main/java/org/sopt/kareer/domain/roadmap/service/RoadmapGenerationSseService.java
+++ b/src/main/java/org/sopt/kareer/domain/roadmap/service/RoadmapGenerationSseService.java
@@ -1,0 +1,81 @@
+package org.sopt.kareer.domain.roadmap.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.kareer.domain.roadmap.dto.response.RoadmapGenerationCompletedEvent;
+import org.sopt.kareer.domain.roadmap.dto.response.RoadmapGenerationFailedEvent;
+import org.sopt.kareer.domain.roadmap.facade.RoadmapGenerateFacade;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapGenerationStep;
+import org.sopt.kareer.domain.roadmap.progress.SseRoadmapProgressNotifier;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutorService;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RoadmapGenerationSseService {
+
+    private static final long SSE_TIMEOUT_MILLIS = 5 * 60 * 1000L;
+    private static final String COMPLETED_EVENT_NAME = "roadmap-completed";
+    private static final String FAILED_EVENT_NAME = "roadmap-failed";
+
+    private final RoadmapGenerateFacade roadmapGenerateFacade;
+    private final ExecutorService executorService;
+
+    public SseEmitter generate(Long memberId) {
+        SseEmitter emitter = new SseEmitter(SSE_TIMEOUT_MILLIS);
+        SseRoadmapProgressNotifier notifier = new SseRoadmapProgressNotifier(emitter);
+
+        emitter.onCompletion(notifier::disconnect);
+        emitter.onTimeout(() -> {
+            notifier.disconnect();
+            emitter.complete();
+        });
+        emitter.onError(exception -> notifier.disconnect());
+
+        executorService.submit(() -> generateRoadmap(memberId, emitter, notifier));
+        return emitter;
+    }
+
+    private void generateRoadmap(
+            Long memberId,
+            SseEmitter emitter,
+            SseRoadmapProgressNotifier notifier
+    ) {
+        try {
+            roadmapGenerateFacade.generateRoadmap(memberId, notifier);
+            send(emitter, notifier, COMPLETED_EVENT_NAME, RoadmapGenerationCompletedEvent.completed());
+        } catch (RuntimeException exception) {
+            RoadmapGenerationStep failedStep = notifier.currentStep() == null
+                    ? RoadmapGenerationStep.USER_ANALYSIS
+                    : notifier.currentStep();
+            send(emitter, notifier, FAILED_EVENT_NAME, RoadmapGenerationFailedEvent.of(failedStep));
+            log.error("[ROADMAP_SSE] roadmap generation failed: memberId={}, step={}",
+                    memberId, failedStep, exception);
+        } finally {
+            emitter.complete();
+        }
+    }
+
+    private void send(
+            SseEmitter emitter,
+            SseRoadmapProgressNotifier notifier,
+            String eventName,
+            Object data
+    ) {
+        if (!notifier.isConnected()) {
+            return;
+        }
+
+        try {
+            emitter.send(SseEmitter.event()
+                    .name(eventName)
+                    .data(data));
+        } catch (IOException | IllegalStateException exception) {
+            notifier.disconnect();
+        }
+    }
+}

--- a/src/main/java/org/sopt/kareer/global/config/security/SecurityConfig.java
+++ b/src/main/java/org/sopt/kareer/global/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package org.sopt.kareer.global.config.security;
 
+import jakarta.servlet.DispatcherType;
 import lombok.RequiredArgsConstructor;
 import org.sopt.kareer.global.jwt.filter.JwtAuthenticationFilter;
 import org.sopt.kareer.global.jwt.filter.JwtExceptionFilter;
@@ -72,6 +73,7 @@ public class SecurityConfig {
                         .failureHandler(failureHandler)
                 )
                 .authorizeHttpRequests(authorize -> authorize
+                        .dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
                         .requestMatchers("/swagger-ui/**", "/swagger-resources/**")
                             .hasRole("SWAGGER")
                         .requestMatchers("/v3/api-docs/**").permitAll()

--- a/src/test/java/org/sopt/kareer/domain/jobposting/repository/JobPostingBookmarkRepositoryTest.java
+++ b/src/test/java/org/sopt/kareer/domain/jobposting/repository/JobPostingBookmarkRepositoryTest.java
@@ -78,7 +78,7 @@ class JobPostingBookmarkRepositoryTest {
         jobPostingBookmarkRepository.save(JobPostingBookmark.create(member, jobPosting3));
 
        //when
-        List<JobPostingBookmark> foundBookmarks = jobPostingBookmarkRepository.findAllByMemberId(member.getId());
+        List<JobPosting> foundBookmarks = jobPostingBookmarkRepository.findAllByMemberId(member.getId());
 
         //then
         assertThat(foundBookmarks.size()).isEqualTo(3);

--- a/src/test/java/org/sopt/kareer/domain/roadmap/controller/RoadmapControllerSseTest.java
+++ b/src/test/java/org/sopt/kareer/domain/roadmap/controller/RoadmapControllerSseTest.java
@@ -1,0 +1,43 @@
+package org.sopt.kareer.domain.roadmap.controller;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.kareer.domain.roadmap.facade.RoadmapGenerateFacade;
+import org.sopt.kareer.domain.roadmap.service.RoadmapGenerationSseService;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapControllerSseTest {
+
+    @Mock
+    private RoadmapGenerateFacade roadmapGenerateFacade;
+
+    @Mock
+    private RoadmapGenerationSseService roadmapGenerationSseService;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @DisplayName("로드맵 생성 SSE 연결을 열고 프록시 버퍼링 방지 헤더를 설정한다")
+    @Test
+    void generateRoadmapStream_returnsEmitterAndSetsHeaders() {
+        RoadmapController controller =
+                new RoadmapController(roadmapGenerateFacade, roadmapGenerationSseService);
+        SseEmitter expected = new SseEmitter();
+        when(roadmapGenerationSseService.generate(1L)).thenReturn(expected);
+
+        SseEmitter actual = controller.generateRoadmapStream(1L, response);
+
+        assertThat(actual).isSameAs(expected);
+        verify(response).setHeader("Cache-Control", "no-cache");
+        verify(response).setHeader("X-Accel-Buffering", "no");
+    }
+}

--- a/src/test/java/org/sopt/kareer/domain/roadmap/dto/response/RoadmapProgressEventTest.java
+++ b/src/test/java/org/sopt/kareer/domain/roadmap/dto/response/RoadmapProgressEventTest.java
@@ -1,0 +1,37 @@
+package org.sopt.kareer.domain.roadmap.dto.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapGenerationStep;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RoadmapProgressEventTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    void 사용자_분석_시작_이벤트를_직렬화한다() throws Exception {
+        RoadmapProgressEvent event = RoadmapProgressEvent.started(
+                RoadmapGenerationStep.USER_ANALYSIS
+        );
+
+        String json = objectMapper.writeValueAsString(event);
+
+        assertThat(json)
+                .contains("\"sequence\":1")
+                .contains("\"step\":\"USER_ANALYSIS\"")
+                .contains("\"status\":\"STARTED\"");
+    }
+
+    @Test
+    void 정책_검색_완료_이벤트를_생성한다() {
+        RoadmapProgressEvent event = RoadmapProgressEvent.completed(
+                RoadmapGenerationStep.POLICY_SEARCH
+        );
+
+        assertThat(event.sequence()).isEqualTo(2);
+        assertThat(event.step()).isEqualTo(RoadmapGenerationStep.POLICY_SEARCH);
+        assertThat(event.status().name()).isEqualTo("COMPLETED");
+    }
+}

--- a/src/test/java/org/sopt/kareer/domain/roadmap/facade/RoadmapGenerateFacadeTest.java
+++ b/src/test/java/org/sopt/kareer/domain/roadmap/facade/RoadmapGenerateFacadeTest.java
@@ -1,0 +1,150 @@
+package org.sopt.kareer.domain.roadmap.facade;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.kareer.domain.member.entity.Member;
+import org.sopt.kareer.domain.member.entity.MemberVisa;
+import org.sopt.kareer.domain.member.service.MemberQueryService;
+import org.sopt.kareer.domain.roadmap.dto.response.RoadmapResponse;
+import org.sopt.kareer.domain.roadmap.dto.translation.RoadmapTranslationTarget;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapGenerationStep;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapProgressNotifier;
+import org.sopt.kareer.domain.roadmap.service.RoadMapPersistService;
+import org.sopt.kareer.domain.roadmap.service.RoadmapGenerateService;
+import org.sopt.kareer.domain.roadmap.service.RoadmapTranslationPersistService;
+import org.sopt.kareer.domain.roadmap.service.dto.response.RoadmapGenerationContext;
+import org.sopt.kareer.global.external.ai.service.OpenAiService;
+import org.sopt.kareer.global.external.google.service.GoogleTranslationService;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapGenerateFacadeTest {
+
+    @Mock
+    private MemberQueryService memberQueryService;
+    @Mock
+    private RoadmapGenerateService roadmapGenerateService;
+    @Mock
+    private OpenAiService openAiService;
+    @Mock
+    private RoadMapPersistService roadMapPersistService;
+    @Mock
+    private RoadmapTranslationPersistService roadmapTranslationPersistService;
+    @Mock
+    private GoogleTranslationService googleTranslationService;
+    @Mock
+    private ExecutorService executorService;
+    @Mock
+    private RoadmapProgressNotifier progress;
+    @Mock
+    private Member member;
+    @Mock
+    private MemberVisa visa;
+
+    private RoadmapGenerateFacade roadmapGenerateFacade;
+
+    @BeforeEach
+    void setUp() {
+        roadmapGenerateFacade = new RoadmapGenerateFacade(
+                memberQueryService,
+                roadmapGenerateService,
+                openAiService,
+                roadMapPersistService,
+                roadmapTranslationPersistService,
+                googleTranslationService,
+                executorService
+        );
+    }
+
+    @Test
+    void 로드맵_생성_진행_상태를_실제_순서대로_알린다() {
+        Long memberId = 1L;
+        RoadmapGenerationContext context = new RoadmapGenerationContext(
+                "member-context",
+                List.of(),
+                List.of(),
+                List.of()
+        );
+        RoadmapResponse response = new RoadmapResponse(List.of());
+        RoadmapTranslationTarget target = new RoadmapTranslationTarget(List.of());
+
+        given(memberQueryService.getMemberById(memberId)).willReturn(member);
+        given(memberQueryService.getVisaByMemberId(memberId)).willReturn(visa);
+        given(roadmapGenerateService.prepareGeneration(
+                eq(member),
+                eq(visa),
+                eq(progress)
+        )).willAnswer(invocation -> {
+            progress.completed(RoadmapGenerationStep.USER_ANALYSIS);
+            progress.started(RoadmapGenerationStep.POLICY_SEARCH);
+            return context;
+        });
+        given(openAiService.generateRoadmap(
+                "member-context",
+                List.of(),
+                List.of(),
+                List.of()
+        )).willReturn(response);
+        given(roadMapPersistService.saveRoadMap(member, response)).willReturn(target);
+
+        roadmapGenerateFacade.generateRoadmap(memberId, progress);
+
+        InOrder order = inOrder(progress);
+        order.verify(progress).started(RoadmapGenerationStep.USER_ANALYSIS);
+        order.verify(progress).completed(RoadmapGenerationStep.USER_ANALYSIS);
+        order.verify(progress).started(RoadmapGenerationStep.POLICY_SEARCH);
+        order.verify(progress).completed(RoadmapGenerationStep.POLICY_SEARCH);
+        order.verify(progress).started(RoadmapGenerationStep.ROADMAP_WRITING);
+        order.verify(progress).completed(RoadmapGenerationStep.ROADMAP_WRITING);
+    }
+
+    @Test
+    void 회원_조회에_실패하면_사용자_분석_실패를_알린다() {
+        given(memberQueryService.getMemberById(1L))
+                .willThrow(new IllegalStateException("member failure"));
+
+        assertThatThrownBy(() -> roadmapGenerateFacade.generateRoadmap(1L, progress))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(progress).failed(RoadmapGenerationStep.USER_ANALYSIS);
+    }
+
+    @Test
+    void OpenAI_호출에_실패하면_로드맵_작성_실패를_알린다() {
+        RoadmapGenerationContext context = new RoadmapGenerationContext(
+                "member-context",
+                List.of(),
+                List.of(),
+                List.of()
+        );
+
+        given(memberQueryService.getMemberById(1L)).willReturn(member);
+        given(memberQueryService.getVisaByMemberId(1L)).willReturn(visa);
+        given(roadmapGenerateService.prepareGeneration(member, visa, progress))
+                .willReturn(context);
+        given(openAiService.generateRoadmap(
+                "member-context",
+                List.of(),
+                List.of(),
+                List.of()
+        )).willThrow(new IllegalStateException("openai failure"));
+
+        assertThatThrownBy(() -> roadmapGenerateFacade.generateRoadmap(1L, progress))
+                .isInstanceOf(IllegalStateException.class);
+
+        verify(progress).failed(RoadmapGenerationStep.ROADMAP_WRITING);
+    }
+
+}

--- a/src/test/java/org/sopt/kareer/domain/roadmap/progress/SseRoadmapProgressNotifierTest.java
+++ b/src/test/java/org/sopt/kareer/domain/roadmap/progress/SseRoadmapProgressNotifierTest.java
@@ -1,0 +1,60 @@
+package org.sopt.kareer.domain.roadmap.progress;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+class SseRoadmapProgressNotifierTest {
+
+    private SseEmitter emitter;
+    private SseRoadmapProgressNotifier notifier;
+
+    @BeforeEach
+    void setUp() {
+        emitter = mock(SseEmitter.class);
+        notifier = new SseRoadmapProgressNotifier(emitter);
+    }
+
+    @Test
+    void 단계_시작_이벤트를_SSE로_전송한다() throws Exception {
+        notifier.started(RoadmapGenerationStep.USER_ANALYSIS);
+
+        verify(emitter, times(1))
+                .send(any(SseEmitter.SseEventBuilder.class));
+        assertThat(notifier.currentStep())
+                .isEqualTo(RoadmapGenerationStep.USER_ANALYSIS);
+    }
+
+    @Test
+    void 연결이_종료되면_이벤트를_더_보내지_않는다() throws Exception {
+        notifier.disconnect();
+
+        notifier.completed(RoadmapGenerationStep.USER_ANALYSIS);
+
+        verify(emitter, times(0))
+                .send(any(SseEmitter.SseEventBuilder.class));
+    }
+
+    @Test
+    void SSE_전송_실패는_비즈니스_예외로_전파하지_않는다() throws Exception {
+        doThrow(new IOException("disconnected"))
+                .when(emitter)
+                .send(any(SseEmitter.SseEventBuilder.class));
+
+        assertThatCode(() -> notifier.started(
+                RoadmapGenerationStep.USER_ANALYSIS
+        )).doesNotThrowAnyException();
+
+        assertThat(notifier.isConnected()).isFalse();
+    }
+}

--- a/src/test/java/org/sopt/kareer/domain/roadmap/service/RoadmapGenerateServiceTest.java
+++ b/src/test/java/org/sopt/kareer/domain/roadmap/service/RoadmapGenerateServiceTest.java
@@ -1,0 +1,126 @@
+package org.sopt.kareer.domain.roadmap.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.kareer.domain.member.entity.Member;
+import org.sopt.kareer.domain.member.entity.MemberVisa;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapGenerationStep;
+import org.sopt.kareer.domain.roadmap.progress.RoadmapProgressNotifier;
+import org.sopt.kareer.domain.roadmap.repository.ActionItemRepository;
+import org.sopt.kareer.domain.roadmap.repository.RoadmapRepository;
+import org.sopt.kareer.domain.roadmap.service.dto.response.RoadmapGenerationContext;
+import org.sopt.kareer.global.external.ai.builder.context.MemberContextBuilder;
+import org.sopt.kareer.global.external.ai.service.PolicyDocumentRetriever;
+import org.sopt.kareer.global.external.ai.service.RequiredDocumentRetriever;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapGenerateServiceTest {
+
+    @Mock
+    private MemberContextBuilder memberContextBuilder;
+    @Mock
+    private RequiredDocumentRetriever requiredRetriever;
+    @Mock
+    private PolicyDocumentRetriever policyDocumentRetriever;
+    @Mock
+    private RoadmapRepository roadmapRepository;
+    @Mock
+    private ActionItemRepository actionItemRepository;
+    @Mock
+    private RoadmapProgressNotifier progress;
+    @Mock
+    private Member member;
+    @Mock
+    private MemberVisa visa;
+
+    private RoadmapGenerateService roadmapGenerateService;
+
+    @BeforeEach
+    void setUp() {
+        roadmapGenerateService = new RoadmapGenerateService(
+                memberContextBuilder,
+                requiredRetriever,
+                policyDocumentRetriever,
+                roadmapRepository,
+                actionItemRepository
+        );
+    }
+
+    @Test
+    void 사용자_분석_완료_후_정책_검색을_시작한다() {
+        given(member.getId()).willReturn(1L);
+        given(roadmapRepository.findByMember_IdAndStatus(1L, org.sopt.kareer.domain.roadmap.entity.enums.RoadmapActiveStatus.ACTIVE))
+                .willReturn(Optional.empty());
+        given(memberContextBuilder.load(1L))
+                .willReturn(new MemberContextBuilder.MemberAndContext(member, "member-context"));
+        given(requiredRetriever.retrieveVisaAll(visa)).willReturn(List.of());
+        given(requiredRetriever.retrieveCareer(member))
+                .willReturn(new RequiredDocumentRetriever.CareerSelectedDocs(
+                        List.of(),
+                        List.of(),
+                        List.of()
+                ));
+        given(policyDocumentRetriever.retrievePolicy(member, visa)).willReturn(List.of());
+
+        RoadmapGenerationContext result = roadmapGenerateService.prepareGeneration(
+                member,
+                visa,
+                progress
+        );
+
+        InOrder order = inOrder(progress);
+        order.verify(progress).completed(RoadmapGenerationStep.USER_ANALYSIS);
+        order.verify(progress).started(RoadmapGenerationStep.POLICY_SEARCH);
+        assertThat(result.memberContextText()).isEqualTo("member-context");
+    }
+
+    @Test
+    void 사용자_Context_생성에_실패하면_사용자_분석_실패를_알린다() {
+        given(member.getId()).willReturn(1L);
+        given(roadmapRepository.findByMember_IdAndStatus(1L, org.sopt.kareer.domain.roadmap.entity.enums.RoadmapActiveStatus.ACTIVE))
+                .willReturn(Optional.empty());
+        given(memberContextBuilder.load(1L))
+                .willThrow(new IllegalStateException("context failure"));
+
+        assertThatThrownBy(() -> roadmapGenerateService.prepareGeneration(
+                member,
+                visa,
+                progress
+        )).isInstanceOf(IllegalStateException.class);
+
+        verify(progress).failed(RoadmapGenerationStep.USER_ANALYSIS);
+    }
+
+    @Test
+    void 문서_검색에_실패하면_정책_검색_실패를_알린다() {
+        given(member.getId()).willReturn(1L);
+        given(roadmapRepository.findByMember_IdAndStatus(1L, org.sopt.kareer.domain.roadmap.entity.enums.RoadmapActiveStatus.ACTIVE))
+                .willReturn(Optional.empty());
+        given(memberContextBuilder.load(1L))
+                .willReturn(new MemberContextBuilder.MemberAndContext(member, "member-context"));
+        given(requiredRetriever.retrieveVisaAll(visa))
+                .willThrow(new IllegalStateException("search failure"));
+
+        assertThatThrownBy(() -> roadmapGenerateService.prepareGeneration(
+                member,
+                visa,
+                progress
+        )).isInstanceOf(IllegalStateException.class);
+
+        verify(progress).failed(RoadmapGenerationStep.POLICY_SEARCH);
+    }
+
+}

--- a/src/test/java/org/sopt/kareer/domain/roadmap/service/RoadmapGenerationSseServiceTest.java
+++ b/src/test/java/org/sopt/kareer/domain/roadmap/service/RoadmapGenerationSseServiceTest.java
@@ -1,0 +1,47 @@
+package org.sopt.kareer.domain.roadmap.service;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.kareer.domain.roadmap.facade.RoadmapGenerateFacade;
+import org.sopt.kareer.domain.roadmap.progress.SseRoadmapProgressNotifier;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.util.concurrent.ExecutorService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RoadmapGenerationSseServiceTest {
+
+    @Mock
+    private RoadmapGenerateFacade roadmapGenerateFacade;
+
+    @Mock
+    private ExecutorService executorService;
+
+    @DisplayName("SSE 연결을 반환하고 로드맵 생성을 별도 스레드에서 시작한다")
+    @Test
+    void generate_startsAsyncRoadmapGeneration() {
+        RoadmapGenerationSseService service =
+                new RoadmapGenerationSseService(roadmapGenerateFacade, executorService);
+
+        SseEmitter emitter = service.generate(1L);
+
+        assertThat(emitter).isNotNull();
+
+        ArgumentCaptor<Runnable> taskCaptor = ArgumentCaptor.forClass(Runnable.class);
+        verify(executorService).submit(taskCaptor.capture());
+
+        taskCaptor.getValue().run();
+
+        verify(roadmapGenerateFacade)
+                .generateRoadmap(eq(1L), any(SseRoadmapProgressNotifier.class));
+    }
+}

--- a/src/test/java/org/sopt/kareer/global/config/security/SecurityConfigAsyncDispatchTest.java
+++ b/src/test/java/org/sopt/kareer/global/config/security/SecurityConfigAsyncDispatchTest.java
@@ -1,0 +1,143 @@
+package org.sopt.kareer.global.config.security;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.sopt.kareer.domain.member.service.MemberQueryService;
+import org.sopt.kareer.domain.roadmap.controller.PhaseController;
+import org.sopt.kareer.domain.roadmap.dto.response.PhaseListResponse;
+import org.sopt.kareer.domain.roadmap.facade.PhaseFacade;
+import org.sopt.kareer.global.external.discord.client.DiscordClient;
+import org.sopt.kareer.global.jwt.filter.JwtAuthenticationFilter;
+import org.sopt.kareer.global.jwt.filter.JwtExceptionFilter;
+import org.sopt.kareer.global.jwt.handler.CustomAccessDeniedHandler;
+import org.sopt.kareer.global.jwt.handler.CustomAuthenticationEntryPoint;
+import org.sopt.kareer.global.jwt.util.JwtTokenUtil;
+import org.sopt.kareer.global.oauth.handler.OAuth2AuthenticationFailureHandler;
+import org.sopt.kareer.global.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import org.sopt.kareer.global.oauth.service.CustomOidcOAuth2UserService;
+import org.sopt.kareer.global.security.filter.OnboardingRestrictionFilter;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.nullable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PhaseController.class)
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Import({SecurityConfig.class, CorsConfig.class})
+class SecurityConfigAsyncDispatchTest {
+
+    @jakarta.annotation.Resource
+    private MockMvc mockMvc;
+
+    @MockBean
+    private PhaseFacade phaseFacade;
+
+    @MockBean
+    private JwtTokenUtil jwtTokenUtil;
+
+    @MockBean
+    private MemberQueryService memberQueryService;
+
+    @MockBean
+    private JpaMetamodelMappingContext mappingContext;
+
+    @MockBean
+    private DiscordClient discordClient;
+
+    @MockBean
+    private CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    @MockBean
+    private CustomAccessDeniedHandler accessDeniedHandler;
+
+    @MockBean
+    private CorsProperties corsProperties;
+
+    @MockBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @MockBean
+    private JwtExceptionFilter jwtExceptionFilter;
+
+    @MockBean
+    private OnboardingRestrictionFilter onboardingRestrictionFilter;
+
+    @MockBean
+    private CustomOidcOAuth2UserService customOidcOAuth2UserService;
+
+    @MockBean
+    private OAuth2AuthenticationSuccessHandler successHandler;
+
+    @MockBean
+    private OAuth2AuthenticationFailureHandler failureHandler;
+
+    @BeforeEach
+    void letSecurityFiltersContinue() throws Exception {
+        doAnswer(invocation -> {
+            invocation.<jakarta.servlet.http.HttpServletResponse>getArgument(1)
+                    .setStatus(jakarta.servlet.http.HttpServletResponse.SC_UNAUTHORIZED);
+            return null;
+        }).when(authenticationEntryPoint).commence(any(), any(), any());
+
+        doAnswer(invocation -> {
+            invocation.<jakarta.servlet.http.HttpServletResponse>getArgument(1)
+                    .setStatus(jakarta.servlet.http.HttpServletResponse.SC_FORBIDDEN);
+            return null;
+        }).when(accessDeniedHandler).handle(any(), any(), any());
+
+        doAnswer(invocation -> {
+            invocation.<jakarta.servlet.FilterChain>getArgument(2)
+                    .doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+
+        doAnswer(invocation -> {
+            invocation.<jakarta.servlet.FilterChain>getArgument(2)
+                    .doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtExceptionFilter).doFilter(any(), any(), any());
+
+        doAnswer(invocation -> {
+            invocation.<jakarta.servlet.FilterChain>getArgument(2)
+                    .doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(onboardingRestrictionFilter).doFilter(any(), any(), any());
+    }
+
+    @DisplayName("인증이 끝난 SSE의 ASYNC 재디스패치는 다시 인증하지 않는다")
+    @Test
+    void asyncDispatch_isPermittedWithoutReauthentication() throws Exception {
+        given(phaseFacade.getPhases(nullable(Long.class)))
+                .willReturn(new PhaseListResponse(List.of()));
+
+        mockMvc.perform(get("/api/v1/roadmap/phases")
+                        .with(request -> {
+                            request.setDispatcherType(jakarta.servlet.DispatcherType.ASYNC);
+                            return request;
+                        }))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Phase 리스트가 조회되었습니다."));
+    }
+
+    @DisplayName("일반 요청은 인증 없이 접근할 수 없다")
+    @Test
+    void normalRequest_stillRequiresAuthentication() throws Exception {
+        mockMvc.perform(get("/api/v1/roadmap/phases"))
+                .andExpect(status().isUnauthorized());
+    }
+}


### PR DESCRIPTION
## Related issue 🛠

- closed #250

## Work Description 📝

### 1. 로드맵 생성 SSE API 추가

기존 로드맵 생성 API는 모든 작업이 끝난 후 최종 응답만 반환했어요.  
이 때문에 로드맵 생성에 시간이 오래 걸려도 프론트에서는 현재 진행 상태를 확인할 수 없었어요.

기존 생성 로직은 유지하면서, 단계별 진행 상태를 실시간으로 전달하는 SSE API를 추가했어요.

```http
POST /api/v1/roadmap/generations/stream
Accept: text/event-stream
```

### 2. 로드맵 생성 단계 구분

화면에 표시되는 단계와 실제 서버 작업이 일치하도록 다음 세 단계로 구분했어요.

| 순서 | 단계 | 실제 서버 작업 |
| --- | --- | --- |
| 1 | `USER_ANALYSIS` | 회원·비자 조회, 기존 로드맵 정리, 사용자 컨텍스트 생성 |
| 2 | `POLICY_SEARCH` | 비자·커리어·정책 문서 검색 |
| 3 | `ROADMAP_WRITING` | OpenAI 로드맵 생성 및 기본 로드맵 DB 저장 |

각 단계의 상태는 다음 enum으로 관리해요.

- `STARTED`: 단계 시작
- `COMPLETED`: 실제 서버 작업 완료
- `FAILED`: 단계 처리 중 실패

화면 연출을 위한 임의의 타이머는 사용하지 않았어요.  
실제 작업이 시작되거나 끝나는 위치에서만 이벤트를 전송하도록 구현했어요.

### 3. SSE 이벤트 구성

클라이언트에는 다음 이벤트를 전달해요.

| 이벤트 이름 | 의미 |
| --- | --- |
| `roadmap-progress` | 단계별 시작·완료·실패 상태 |
| `roadmap-completed` | 원문 로드맵 생성 및 DB 저장 완료 |
| `roadmap-failed` | 전체 로드맵 생성 실패 |

정상 처리 시 이벤트는 다음 순서로 전달돼요.

```text
USER_ANALYSIS STARTED
USER_ANALYSIS COMPLETED
POLICY_SEARCH STARTED
POLICY_SEARCH COMPLETED
ROADMAP_WRITING STARTED
ROADMAP_WRITING COMPLETED
roadmap-completed
```

실패 시에는 현재 단계의 `FAILED` 이벤트를 먼저 전달하고, 이후 `roadmap-failed` 이벤트를 전달해요.

### 4. 진행 알림 구조 분리

로드맵 생성 로직이 `SseEmitter`에 직접 의존하지 않도록 `RoadmapProgressNotifier` 인터페이스를 추가했어요.

구현체는 다음 두 가지로 구분했어요.

- `SseRoadmapProgressNotifier`
  - SSE API에서 사용해요.
  - 진행 상태를 실제 SSE 이벤트로 전달해요.
- `NoOpRoadmapProgressNotifier`
  - 기존 일반 생성 API에서 사용해요.
  - 이벤트는 전송하지 않고 기존 로드맵 생성 로직만 실행해요.

이를 통해 기존 API와 SSE API가 서로 다른 생성 로직을 갖지 않고 같은 로직을 재사용하도록 했어요.

### 5. 비동기 실행 및 SSE 연결 관리

로드맵 생성 작업은 기존 가상 스레드 `ExecutorService`에서 실행하도록 했어요.

처리 순서는 다음과 같아요.

1. `SseEmitter`를 생성해 클라이언트에 먼저 반환해요.
2. 별도 가상 스레드에서 로드맵 생성을 시작해요.
3. 실제 처리 단계에 맞춰 SSE 이벤트를 전달해요.
4. 성공 또는 실패 이벤트를 전달한 후 연결을 종료해요.

SSE 연결 제한 시간은 5분으로 설정했어요.

클라이언트가 화면을 이탈하거나 네트워크 연결이 끊긴 경우에는 SSE 이벤트 전송만 중단해요.  
이미 시작한 로드맵 생성과 DB 저장 작업은 계속 진행하도록 했어요.

### 6. SSE 응답 및 Security 설정

프록시가 이벤트를 모아서 한 번에 전달하지 않도록 다음 응답 헤더를 추가했어요.

```http
Cache-Control: no-cache
X-Accel-Buffering: no
```

SSE 처리 후 발생할 수 있는 Servlet `ASYNC` 재디스패치가 다시 인증되지 않도록 Security 설정도 추가했어요.

```java
.dispatcherTypeMatchers(DispatcherType.ASYNC).permitAll()
```

최초 일반 요청은 기존과 동일하게 JWT 인증이 필요하고, 인증이 완료된 요청의 내부 `ASYNC` 재디스패치만 허용해요.

### 7. 기존 로드맵 생성 동작 유지

이번 작업에서는 진행 상태 전달 기능만 추가하고 기존 생성 정책은 변경하지 않았어요.

다음 동작은 기존과 동일하게 유지해요.

- 기존 활성 로드맵과 Action Item 비활성화
- 사용자 컨텍스트 생성
- 벡터 DB 문서 검색
- OpenAI 로드맵 생성
- 기본 로드맵 DB 저장
- 다국어 번역 비동기 실행

`ROADMAP_WRITING COMPLETED`와 `roadmap-completed`는 원문 로드맵 생성 및 DB 저장이 끝난 시점을 의미해요.

다국어 번역은 기존처럼 별도 가상 스레드에서 실행하며, SSE 완료 이벤트는 번역 완료까지 기다리지 않아요.

### 8. 북마크 조회 쿼리 수정

북마크 공고 조회 쿼리는 `JobPostingBookmark`가 아니라 연관된 `JobPosting`을 직접 반환하고 있어요.

조회 대상에 맞지 않게 적용돼 있던 `JOIN FETCH`를 일반 `JOIN`으로 변경했어요.

```sql
SELECT jp
FROM JobPostingBookmark jpb
JOIN jpb.jobPosting jp
```

Repository 테스트의 반환 타입도 실제 쿼리 결과에 맞게 `List<JobPosting>`으로 수정했어요.

### 9. 테스트 추가

다음 내용을 검증하는 테스트를 추가했어요.

- 진행 단계와 상태의 JSON 직렬화
- SSE 단계 이벤트 전송
- 연결 종료 후 추가 이벤트 전송 방지
- SSE 전송 실패가 비즈니스 로직에 영향을 주지 않는지
- 사용자 분석 및 정책 검색의 이벤트 순서
- 단계별 실패 이벤트 처리
- Facade 전체 이벤트 순서
- SSE 작업이 별도 스레드에서 실행되는지
- SSE 응답 헤더 설정
- Security `ASYNC` 재디스패치 허용
- 일반 요청의 기존 인증 유지
- 북마크 공고 조회

전체 테스트 통과를 확인했어요.

```bash
./gradlew test
```

## ScreenShots 📷

- 서버 SSE 및 내부 구조 변경 작업으로 별도의 UI 스크린샷은 없어요.

## To Reviewers 📢

### SSE를 선택한 이유

이 기능은 클라이언트가 서버에 지속적으로 메시지를 보내는 구조가 아니라, 서버가 진행 상태를 클라이언트에 전달하는 단방향 통신이에요.

양방향 통신이 필요한 WebSocket보다 SSE가 현재 요구사항에 더 적합하다고 판단했어요.

### POST SSE를 사용한 이유

로드맵 생성은 단순 조회가 아니라 새로운 생성을 시작하는 요청이며, JWT `Authorization` 헤더도 필요해요.

브라우저 기본 `EventSource`는 GET 기반이고 인증 헤더 설정이 제한적이기 때문에 POST SSE로 구현했어요.  
프론트에서는 `@microsoft/fetch-event-source`와 같은 fetch 기반 SSE 클라이언트 사용을 전제로 했어요.

### Facade에서 진행 순서를 관리한 이유

`RoadmapGenerateFacade`는 회원 조회, 문서 검색, OpenAI 호출, DB 저장과 번역 작업의 전체 순서를 알고 있어요.

따라서 사용자 관점의 큰 단계 전환은 Facade가 관리하도록 했어요.

다만 사용자 컨텍스트 생성 완료와 정책 검색 시작의 정확한 경계는 `RoadmapGenerateService` 내부에서만 알 수 있어요.  
이 두 이벤트는 실제 작업 위치와 일치하도록 해당 Service에서 전달하도록 했어요.

### Notifier를 분리한 이유

로드맵 생성 로직에서 `SseEmitter`를 직접 사용하면 비즈니스 로직이 SSE 기술에 종속돼요.

이를 방지하기 위해 `RoadmapProgressNotifier`를 두고, SSE 전송 여부는 구현체가 결정하도록 분리했어요.

이 구조를 통해 다음 사항을 유지할 수 있어요.

- 기존 생성 API와 SSE API가 동일한 생성 로직을 사용해요.
- 테스트에서 실제 SSE 연결 없이 이벤트 순서를 검증할 수 있어요.
- 향후 알림 방식이 변경되더라도 생성 로직의 변경을 최소화할 수 있어요.

### 확인이 필요한 사항

- 초기 `USER_ANALYSIS`, `POLICY_SEARCH` 단계는 빠르게 지나갈 수 있어요.
- 전체 처리 시간은 OpenAI 호출이 포함된 `ROADMAP_WRITING` 단계에 집중될 수 있어요.
- 각 단계는 균등한 진행률이 아니라 실제 서버 작업 경계를 의미해요.
- SSE 연결이 끊겨도 이미 시작한 로드맵 생성 작업은 계속 진행해요.
- `roadmap-completed`는 번역 완료가 아니라 원문 로드맵 생성·저장 완료를 의미해요.
- 현재는 재연결, 이벤트 재생, 중복 요청 방지 및 서버 재시작 후 작업 복구 기능을 포함하지 않았어요.
- 위 기능들이 필요해지면 `generationId`와 작업 상태 저장소를 사용하는 비동기 Job 구조로 확장하는 것이 적절하다고 생각해요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * AI 로드맵 생성 과정을 실시간 SSE 스트림으로 확인할 수 있습니다.
  * 사용자 분석, 정책 검색, 로드맵 작성 단계별 시작·완료·실패 상태를 제공합니다.
  * 생성 완료 또는 실패 시 관련 상태와 오류 정보를 전달합니다.

* **개선**
  * 비동기 SSE 요청이 인증 절차를 중복 수행하지 않도록 개선했습니다.
  * 작업 중 연결 종료나 전송 오류를 안정적으로 처리합니다.
  * 북마크 게시글 조회 성능을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->